### PR TITLE
meta: decharter the Docs and Testing Working Groups

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -42,8 +42,6 @@ Top Level Working Group](https://github.com/nodejs/TSC/blob/master/WORKING_GROUP
 * [Benchmarking](#benchmarking)
 * [Post-mortem](#post-mortem)
 * [Intl](#intl)
-* [Documentation](#documentation)
-* [Testing](#testing)
 
 
 ### [Website](https://github.com/nodejs/nodejs.org)
@@ -251,30 +249,3 @@ Responsibilities include:
   to be generated when needed.
 * Defining and adding common structures to the dumps generated
   in order to support tools that want to introspect those dumps.
-
-### [Documentation](https://github.com/nodejs/docs)
-
-The Documentation Working Group exists to support the improvement of Node.js
-documentation, both in the core API documentation, and elsewhere, such as the
-Node.js website. Its intent is to work closely with the Evangelism, Website, and
-Intl Working Groups to make excellent documentation available and accessible
-to all.
-
-Responsibilities include:
-* Defining and maintaining documentation style and content standards.
-* Producing documentation in a format acceptable for the Website Working Group
-  to consume.
-* Ensuring that Node's documentation addresses a wide variety of audiences.
-* Creating and operating a process for documentation review that produces
-  quality documentation and avoids impeding the progress of Core work.
-
-### [Testing](https://github.com/nodejs/testing)
-
-The Node.js Testing Working Group's purpose is to extend and improve testing of
-the Node.js source code.
-
-Responsibilities include:
-* Coordinating an overall strategy for improving testing.
-* Documenting guidelines around tests.
-* Working with the Build Working Group to improve continuous integration.
-* Improving tooling for testing.


### PR DESCRIPTION
The Documentation and Testing Working Groups are not active and have not been in some time. The existing teams may remain, but the associated nodejs/testing and nodejs/docs repositories should be archived, the charters revoked, and the responsibilities folded back into the CTC.

/cc @nodejs/ctc @nodejs/testing @nodejs/documentation 