### PR TITLE
extend meeting calendar through June

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,13 @@ Meta technical matters to be discussed here include, but are not limited to:
 
 ## Meeting Schedule
 
-|  UTC | San Francisco  | New York | Amsterdam | Moscow | Chennai | Tokyo | Sydney |
-| ---- | -------------- | -------- | --------- | ------ | ------- | ----- | ------ |
-|Wednesday, April 26, 2017 at 20:00:00	|Wed 1:00 pm *	|Wed 4:00 pm *	|Wed 10:00 pm *	|Wed 11:00 pm	|Thu 1:30 am	|Thu 5:00 am	|Thu 6:00 am|
-|Wednesday, May 3, 2017 at 05:00:00|	Tue 10:00 pm *	|Wed 1:00 am *	|Wed 7:00 am *|	Wed 8:00 am	|Wed 10:30 am|	Wed 2:00 pm	|Wed 3:00 pm|
-|Wednesday, May 10, 2017 at 16:00:00 |Wed 9:00 am * |Wed 12:00 noon *  |Wed 6:00 pm * |Wed 7:00 pm |Wed 9:30 pm |Thu 1:00 am |Thu 2:00 am|
-|Wednesday, May 17, 2017 at 20:00:00 |Wed 1:00 pm * |Wed 4:00 pm * |Wed 10:00 pm *  |Wed 11:00 pm  |Thu 1:30 am |Thu 5:00 am |Thu 6:00 am|
-|Wednesday, May 24, 2017 at 11:00:00  |Wed 4:00 am * |Wed 7:00 am * |Wed 1:00 pm * |Wed 2:00 pm |Wed 4:30 pm| Wed 8:00 pm |Wed 9:00 pm|
-|Wednesday, May 31, 2017 at 16:00:00 | Wed 9:00 am * |Wed 12:00 noon *  |Wed 6:00 pm * |Wed 7:00 pm| Wed 9:30 pm| Thu 1:00 am |Thu 2:00 am|
-|Wednesday, June 7, 2017 at 20:00:00  |Wed 1:00 pm * |Wed 4:00 pm * |Wed 10:00 pm *  |Wed 11:00 pm | Thu 1:30 am |Thu 5:00 am |Thu 6:00 am|
+|  UTC | San Francisco  | New York | Amsterdam | Moscow | Chennai | Shanghai | Tokyo | Sydney |
+| ---- | -------------- | -------- | --------- | ------ | ------- | -------- | ----- | ------ |
+|Wed, May 31, 2017 at 16:00:00 | Wed 9:00 am * | Wed 12:00 noon * | Wed 6:00 pm * | Wed 7:00 pm | Wed 9:30 pm | Thu midnight | Thu 1:00 am | Thu 2:00 am|
+|Wed, June 7, 2017 at 20:00:00 | Wed 1:00 pm * | Wed 4:00 pm * | Wed 10:00 pm * | Wed 11:00 pm | Thu 1:30 am | Thu 4:00 am | Thu 5:00 am | Thu 6:00 am|
+|Wed, June 14, 2017 at 11:00:00 | Wed 4:00 am * | Wed 7:00 am * | Wed 1:00 pm * | Wed 2:00 pm | Wed 4:30 pm | Wed 7:00 pm | Wed 8:00 pm | Wed 9:00 pm|
+|Wed, June 21, 2017 at 16:00:00 | Wed 9:00 am * | Wed 12:00 noon * | Wed 6:00 pm * | Wed 7:00 pm | Wed 9:30 pm | Thu midnight | Thu 1:00 am |Thu 2:00 am|
+|Wed, June 28, 2017 at 20:00:00 | Wed 1:00 pm * | Wed 4:00 pm * | Wed 10:00 pm * | Wed 11:00 pm | Thu 1:30 am | Thu 4:00 am | Thu 5:00 am | Thu 6:00 am|
+|Wed, July 5, 2017 at 11:00:00 | Wed 4:00 am * | Wed 7:00 am * | Wed 1:00 pm * | Wed 2:00 pm | Wed 4:30 pm | Wed 7:00 pm | Wed 8:00 pm | Wed 9:00 pm|
 
 Asterisk (`*`) in the above table denotes daylight savings time is in effect in that location.


### PR DESCRIPTION
Keeping the three current times for now because there's no obvious improvement I could find. (Lots of interesting possibilities to consider, but nothing that was without significant trade-offs.)

Once the current nominees are added to the group, it might make sense to try to make it so that everyone has at least one meeting that is during (or at least very near) ordinary business hours. Right now, China/Japan/Australia don't. Not sure if it's best to tweak the current set of three times or to simply add a fourth time.