### PR TITLE
Update URL for Docker WG

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -186,7 +186,7 @@ Responsibilities include:
 * Publishing regular update summaries and other promotional
   content.
 
-### [Docker](https://github.com/nodejs/docker-iojs)
+### [Docker](https://github.com/nodejs/docker-node)
 
 The Docker Working Group's purpose is to build, maintain, and improve official
 Docker images for the Node.js project.


### PR DESCRIPTION
I noticed that the Docker WG repo URL goes to [nodejs/docker-iojs](https://github.com/nodejs/docker-iojs), not [nodejs/docker-node](https://github.com/nodejs/docker-node) (which as far as I know is the currently maintained repo). Just wanted to submit a quick fix if it is, in fact, incorrect.