### PR TITLE
meta: remove the Evanglism WG

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -36,7 +36,6 @@ Top Level Working Group](https://github.com/nodejs/TSC/blob/master/WORKING_GROUP
 * [Build](#build)
 * [Diagnostics](#diagnostics)
 * [i18n](#i18n)
-* [Evangelism](#evangelism)
 * [Docker](#docker)
 * [Addon API](#addon-api)
 * [Benchmarking](#benchmarking)


### PR DESCRIPTION
The Evangelism WG has moved to the Community Committee as per https://github.com/nodejs/CTC/issues/145 and https://github.com/nodejs/community-committee/issues/86. This PR removes the Evangelism WG from the list of WGs under the CTC.