### PR TITLE
nodejs-hi is Hindi (हिंदी), not Fiji Hindi (फिजी बात)

### DIFF
--- a/WORKING_GROUPS.md
+++ b/WORKING_GROUPS.md
@@ -135,7 +135,7 @@ Each language community maintains its own membership.
 * [nodejs-fi - Finnish (Suomi)](https://github.com/nodejs/nodejs-fi)
 * [nodejs-fr - French (Français)](https://github.com/nodejs/nodejs-fr)
 * [nodejs-he - Hebrew (עברית)](https://github.com/nodejs/nodejs-he)
-* [nodejs-hi - Hindi (फिजी बात)](https://github.com/nodejs/nodejs-hi)
+* [nodejs-hi - Hindi (हिंदी)](https://github.com/nodejs/nodejs-hi)
 * [nodejs-hu - Hungarian (Magyar)](https://github.com/nodejs/nodejs-hu)
 * [nodejs-id - Indonesian (Bahasa Indonesia)](https://github.com/nodejs/nodejs-id)
 * [nodejs-it - Italian (Italiano)](https://github.com/nodejs/nodejs-it)


### PR DESCRIPTION
Fiji Hindi / फिजी बात is a dialect, and has the language code `hif`, not `hi`.

The repo seems to be doing Hindi, not Fiji Hindi, so switching the language name used.